### PR TITLE
ASNIDE-311 Implemented parsing and storing integer constraints

### DIFF
--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -79,14 +79,23 @@ private:
 
     std::unique_ptr<Data::Types::Type> readType();
     std::unique_ptr<Data::Types::Type> readTypeDetails(const Data::SourceLocation &location);
-    std::unique_ptr<Data::Types::Type> readReferenceType(const Data::SourceLocation &location);
     std::unique_ptr<Data::Types::Type> buildTypeFromName(const Data::SourceLocation &location,
-                                                         const QStringRef &name);
+                                                         const QStringRef &name,
+                                                         bool isParametrized);
+    std::unique_ptr<Data::Types::Type> createReferenceType(const Data::SourceLocation &location);
 
-    void readTypeContents(const QStringRef &name);
+    void readTypeContents(const QStringRef &name, std::unique_ptr<Data::Types::Type> &type);
+
     void readSequence();
     void readSequenceOf();
     void readChoice();
+    void readReferenceType(std::unique_ptr<Data::Types::Type> &type);
+    void readInteger(std::unique_ptr<Data::Types::Type> &type);
+
+    void readConstraint(std::unique_ptr<Data::Types::Type> &type, const QString &valName);
+    void readRanges(std::unique_ptr<Data::Types::Type> &type, const QString &valName);
+    void readRange(std::unique_ptr<Data::Types::Type> &type, const QString &valName);
+    QString readValue(const QString &valName);
 
     QString readTypeAssignmentAttribute();
     QString readModuleAttribute();

--- a/src/lib/data/constraint.h
+++ b/src/lib/data/constraint.h
@@ -25,34 +25,33 @@
 ****************************************************************************/
 #pragma once
 
-#include <QString>
+#include <functional>
 
-#include <data/constraint.h>
+#include <QPair>
+#include <QString>
+#include <QVariant>
 
 namespace MalTester {
 namespace Data {
-namespace Types {
 
-class Type
+class Constraint
 {
 public:
-    Type()
-        : m_constraint(nullptr)
+    using VariantPair = QPair<QVariant, QVariant>;
+    using StringPair = QPair<QString, QString>;
+    using Ranges = QList<VariantPair>;
+
+    Constraint(std::function<VariantPair(StringPair)> convert)
+        : m_convertRange(convert)
     {}
-    virtual ~Type() { delete m_constraint; }
 
-    virtual QString name() const = 0;
-    virtual QString label() const = 0;
-
-    Constraint *constraint() const { return m_constraint; }
-
-protected:
-    Constraint *m_constraint;
+    const Ranges &ranges() const { return m_ranges; }
+    void addRange(const StringPair &range) { m_ranges.push_back(m_convertRange(range)); }
 
 private:
-    virtual QString baseIconFile() const = 0;
+    Ranges m_ranges;
+    std::function<VariantPair(StringPair)> m_convertRange;
 };
 
-} // namespace Types
 } // namespace Data
 } // namespace MalTester

--- a/src/lib/data/types/builtintypes.h
+++ b/src/lib/data/types/builtintypes.h
@@ -70,12 +70,19 @@ private:
 class Integer : public BuiltinType
 {
 public:
+    Integer() { m_constraint = new Constraint(Integer::toVariantPair); }
+
     QString name() const override { return QLatin1String("INTEGER"); }
 
 private:
     QString baseIconFile() const override
     {
         return QStringLiteral(":/asn1acn/images/outline/integer.png");
+    }
+
+    static Constraint::VariantPair toVariantPair(const Constraint::StringPair &range)
+    {
+        return {range.first.toInt(), range.second.toInt()};
     }
 };
 

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -41,6 +41,7 @@ HEADERS += \
     data/valueassignment.h \
     data/visitor.h \
     data/visitorwithvalue.h \
+    data/constraint.h \
     \
     data/types/builtintypes.h \
     data/types/labeltype.h \

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -60,6 +60,8 @@ private slots:
     void test_multipleModules();
     void test_multipleFiles();
     void test_parametrizedInstancesContentsAreIgnored();
+    void test_singleTypeAssignmentWithRangedConstraints();
+    void test_singleTypeAssignmentWithSimpleConstraint();
 
 private:
     void setXmlData(const QString &str);


### PR DESCRIPTION
1. There are constraints, which are ranges or single numbers, but I decided, that (at least for now) all the constraints will be stored as pairs of numbers. 

2. Constraints leave the parser as QStrings, and later are changed to QVariants. This is to keep the parser simple. There is a new class introduced: `Constraints`, which is part of `Type` from now on. Class `Constraint` is basic storage class, which is customized by passing function responsible for converting mentioned before QStrings to QVariants of correct type. It could be made easier for ints, but I believe this approach will make handling other types easier. 