### PR TITLE
ASNIDE-318 Implemented parsing REAL type constraints

### DIFF
--- a/src/lib/astxmlparser.cpp
+++ b/src/lib/astxmlparser.cpp
@@ -324,6 +324,8 @@ void AstXmlParser::readTypeContents(const QStringRef &name, std::unique_ptr<Data
         readReferenceType(type);
     else if (name == QStringLiteral("INTEGER"))
         readInteger(type);
+    else if (name == QStringLiteral("REAL"))
+        readReal(type);
     else
         m_xmlReader.skipCurrentElement();
 }
@@ -354,6 +356,11 @@ void AstXmlParser::readInteger(std::unique_ptr<Data::Types::Type> &type)
 {
     readIntegerAcnParams(type);
     readConstraint(type, "IntegerValue");
+}
+
+void AstXmlParser::readReal(std::unique_ptr<Data::Types::Type> &type)
+{
+    readConstraint(type, "RealValue");
 }
 
 void AstXmlParser::readIntegerAcnParams(std::unique_ptr<Data::Types::Type> &type)

--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -96,6 +96,8 @@ private:
     void readInteger(std::unique_ptr<Data::Types::Type> &type);
     void readIntegerAcnParams(std::unique_ptr<Data::Types::Type> &type);
 
+    void readReal(std::unique_ptr<Data::Types::Type> &type);
+
     void readConstraint(std::unique_ptr<Data::Types::Type> &type, const QString &valName);
     void readRanges(std::unique_ptr<Data::Types::Type> &type, const QString &valName);
     void readRange(std::unique_ptr<Data::Types::Type> &type, const QString &valName);

--- a/src/lib/data/types/builtintypes.cpp
+++ b/src/lib/data/types/builtintypes.cpp
@@ -25,7 +25,9 @@
 ****************************************************************************/
 
 #include "builtintypes.h"
+
 #include "integertype.h"
+#include "realtype.h"
 
 using namespace MalTester::Data::Types;
 

--- a/src/lib/data/types/builtintypes.h
+++ b/src/lib/data/types/builtintypes.h
@@ -68,18 +68,6 @@ private:
     }
 };
 
-class Real : public BuiltinType
-{
-public:
-    QString name() const override { return QLatin1String("REAL"); }
-
-private:
-    QString baseIconFile() const override
-    {
-        return QStringLiteral(":/asn1acn/images/outline/real.png");
-    }
-};
-
 class BitString : public BuiltinType
 {
 public:

--- a/src/lib/data/types/realtype.h
+++ b/src/lib/data/types/realtype.h
@@ -27,7 +27,6 @@
 
 #include <QString>
 
-#include <data/acnparameters.h>
 #include <data/constraint.h>
 
 #include <data/types/builtintypes.h>
@@ -36,55 +35,22 @@ namespace MalTester {
 namespace Data {
 namespace Types {
 
-class IntegerAcnParameters : public AcnParameters
+class Real : public BuiltinType
 {
 public:
-    IntegerAcnParameters()
-        : m_size(0)
-        , m_encoding(Encoding::undefined)
-        , m_endianness(Endianness::undefined)
-        , m_alignToNext(AlignToNext::undefined)
-    {}
+    Real() { m_constraint = new Constraint(Real::toVariantPair); }
 
-    void setSize(const int size) override { m_size = size; }
-    int size() const override { return m_size; }
-
-    void setEncoding(const Encoding encoding) override { m_encoding = encoding; }
-    Encoding encoding() const override { return m_encoding; }
-
-    void setEndianness(const Endianness endianness) override { m_endianness = endianness; }
-    Endianness endianness() const override { return m_endianness; }
-
-    void setAlignToNext(const AlignToNext alignToNext) override { m_alignToNext = alignToNext; }
-    AlignToNext alignToNext() const override { return m_alignToNext; }
-
-private:
-    int m_size;
-    Encoding m_encoding;
-    Endianness m_endianness;
-    AlignToNext m_alignToNext;
-};
-
-class Integer : public BuiltinType
-{
-public:
-    Integer()
-    {
-        m_constraint = new Constraint(Integer::toVariantPair);
-        m_acnParams = new IntegerAcnParameters;
-    }
-
-    QString name() const override { return QLatin1String("INTEGER"); }
+    QString name() const override { return QLatin1String("REAL"); }
 
 private:
     QString baseIconFile() const override
     {
-        return QStringLiteral(":/asn1acn/images/outline/integer.png");
+        return QStringLiteral(":/asn1acn/images/outline/real.png");
     }
 
     static Constraint::VariantPair toVariantPair(const Constraint::StringPair &range)
     {
-        return {range.first.toInt(), range.second.toInt()};
+        return {range.first.toDouble(), range.second.toDouble()};
     }
 };
 

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -50,6 +50,7 @@ HEADERS += \
     data/types/type.h \
     data/types/userdefinedtype.h \
     data/types/integertype.h \
+    data/types/realtype.h \
     \
     astxmlparser.h \
     runparameters.h \

--- a/src/tests/astxmlparser_tests.cpp
+++ b/src/tests/astxmlparser_tests.cpp
@@ -649,7 +649,7 @@ void AstXmlParserTests::test_parametrizedInstancesContentsAreIgnored()
     QVERIFY(ref == m_parsedData["Test2File.asn"]->referencesMap().end());
 }
 
-void AstXmlParserTests::test_singleTypeAssignmentWithSimpleConstraint()
+void AstXmlParserTests::test_singleIntegerTypeAssignmentWithSimpleConstraint()
 {
     parse(
         R"(<?xml version="1.0" encoding="utf-8"?>)"
@@ -674,23 +674,14 @@ void AstXmlParserTests::test_singleTypeAssignmentWithSimpleConstraint()
         R"(  </Asn1File>)"
         R"(</AstRoot>)");
 
-    QCOMPARE(m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->types().size(),
-             std::size_t{1});
     const auto type = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyInt");
-    QCOMPARE(type->name(), QStringLiteral("MyInt"));
-    QCOMPARE(type->location().path(), QStringLiteral("Test2File.asn"));
-    QCOMPARE(type->location().line(), 4);
-    QCOMPARE(type->location().column(), 10);
+    const auto constraintRanges = type->type()->constraint()->ranges();
 
-    QCOMPARE(type->parent(), m_parsedData["Test2File.asn"]->definitions("TestDefinitions"));
-
-    auto constraintRanges = type->type()->constraint()->ranges();
     QCOMPARE(constraintRanges.size(), 1);
-
     QVERIFY(constraintRanges.contains(QPair<QVariant, QVariant>(1, 1)));
 }
 
-void AstXmlParserTests::test_singleTypeAssignmentWithRangedConstraints()
+void AstXmlParserTests::test_singleIntegerTypeAssignmentWithRangedConstraints()
 {
     parse(R"(<?xml version="1.0" encoding="utf-8"?>)"
           R"(<AstRoot>)"
@@ -750,17 +741,9 @@ void AstXmlParserTests::test_singleTypeAssignmentWithRangedConstraints()
           R"(  </Asn1File>)"
           R"(</AstRoot>)");
 
-    QCOMPARE(m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->types().size(),
-             std::size_t{1});
     const auto type = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyInt");
-    QCOMPARE(type->name(), QStringLiteral("MyInt"));
-    QCOMPARE(type->location().path(), QStringLiteral("Test2File.asn"));
-    QCOMPARE(type->location().line(), 4);
-    QCOMPARE(type->location().column(), 10);
+    const auto constraintRanges = type->type()->constraint()->ranges();
 
-    QCOMPARE(type->parent(), m_parsedData["Test2File.asn"]->definitions("TestDefinitions"));
-
-    auto constraintRanges = type->type()->constraint()->ranges();
     QCOMPARE(constraintRanges.size(), 6);
 
     QVERIFY(constraintRanges.contains(QPair<QVariant, QVariant>(10, 20)));
@@ -771,7 +754,7 @@ void AstXmlParserTests::test_singleTypeAssignmentWithRangedConstraints()
     QVERIFY(constraintRanges.contains(QPair<QVariant, QVariant>(50, 80)));
 }
 
-void AstXmlParserTests::test_singleTypeAssignmentWitAcnData()
+void AstXmlParserTests::test_singleIntegerTypeAssignmentWitAcnData()
 {
     parse(
         R"(<?xml version="1.0" encoding="utf-8"?>)"
@@ -803,6 +786,93 @@ void AstXmlParserTests::test_singleTypeAssignmentWitAcnData()
     QCOMPARE(acnParams->encoding(), Data::Encoding::BCD);
     QCOMPARE(acnParams->endianness(), Data::Endianness::big);
     QCOMPARE(acnParams->alignToNext(), Data::AlignToNext::dword);
+}
+
+void AstXmlParserTests::test_singleRealTypeAssignmentWithSimpleConstraint()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyReal" Line="4" CharPositionInLine="10">)"
+        R"(            <Asn1Type id="Constrained.MyReal" Line="3" CharPositionInLine="14" ParameterizedTypeInstance="false">"
+        R"(              <REAL>"
+        R"(                <Constraints>"
+        R"(                  <RealValue>1.1</RealValue>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </REAL>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyReal");
+    auto constraintRanges = type->type()->constraint()->ranges();
+
+    QCOMPARE(constraintRanges.size(), 1);
+    QVERIFY(qFuzzyCompare(constraintRanges.at(0).first.toDouble(), 1.1));
+    QVERIFY(qFuzzyCompare(constraintRanges.at(0).second.toDouble(), 1.1));
+}
+
+void AstXmlParserTests::test_singleRealTypeAssignmentWithRangedConstraints()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyReal" Line="4" CharPositionInLine="10">)"
+        R"(            <Asn1Type id="Constrained.MyReal" Line="3" CharPositionInLine="14" ParameterizedTypeInstance="false">"
+        R"(              <REAL>"
+        R"(                <Constraints>"
+        R"(                  <OR>"
+        R"(                    <Range>"
+        R"(                      <a>"
+        R"(                        <RealValue>1.1</RealValue>"
+        R"(                      </a>"
+        R"(                      <b>"
+        R"(                        <RealValue>2.5</RealValue>"
+        R"(                      </b>"
+        R"(                    </Range>"
+        R"(                    <Range>"
+        R"(                      <a>"
+        R"(                        <RealValue>4.5</RealValue>"
+        R"(                      </a>"
+        R"(                      <b>"
+        R"(                        <RealValue>5.5</RealValue>"
+        R"(                      </b>"
+        R"(                    </Range>"
+        R"(                  </OR>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </REAL>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyReal");
+    auto constraintRanges = type->type()->constraint()->ranges();
+
+    QCOMPARE(constraintRanges.size(), 2);
+
+    QVERIFY(qFuzzyCompare(constraintRanges.at(0).first.toDouble(), 1.1));
+    QVERIFY(qFuzzyCompare(constraintRanges.at(0).second.toDouble(), 2.5));
+
+    QVERIFY(qFuzzyCompare(constraintRanges.at(1).first.toDouble(), 4.5));
+    QVERIFY(qFuzzyCompare(constraintRanges.at(1).second.toDouble(), 5.5));
 }
 
 void AstXmlParserTests::parsingFails(const QString &xmlData)

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -60,9 +60,13 @@ private slots:
     void test_multipleModules();
     void test_multipleFiles();
     void test_parametrizedInstancesContentsAreIgnored();
-    void test_singleTypeAssignmentWithRangedConstraints();
-    void test_singleTypeAssignmentWithSimpleConstraint();
-    void test_singleTypeAssignmentWitAcnData();
+
+    void test_singleIntegerTypeAssignmentWithSimpleConstraint();
+    void test_singleIntegerTypeAssignmentWithRangedConstraints();
+    void test_singleIntegerTypeAssignmentWitAcnData();
+
+    void test_singleRealTypeAssignmentWithSimpleConstraint();
+    void test_singleRealTypeAssignmentWithRangedConstraints();
 
 private:
     void setXmlData(const QString &str);


### PR DESCRIPTION
Improved tests added in previous pull requests, by removing checking if location, names etc. was parsed correctly. This emphasizes the real purpose of the test and makes it much more readable. 