### PR TITLE
Asnide 322 323 parsing choice alternatives and acn params

### DIFF
--- a/src/lib/astxmlparser.cpp
+++ b/src/lib/astxmlparser.cpp
@@ -389,6 +389,11 @@ int AstXmlParser::readCharPossitionInLineAttribute()
     return m_xmlReader.attributes().value(QStringLiteral("CharPositionInLine")).toInt();
 }
 
+QString AstXmlParser::readDeterminantAttribute()
+{
+    return m_xmlReader.attributes().value("determinant").toString();
+}
+
 QString AstXmlParser::readPresentWhenNameAttribute()
 {
     return m_xmlReader.attributes().value("PresentWhenName").toString();
@@ -601,17 +606,23 @@ void AstXmlParser::readSequenceOf(Data::Types::Type &type)
 void AstXmlParser::readChoice(Data::Types::Type &type)
 {
     auto &choiceType = dynamic_cast<Data::Types::Choice &>(type);
+    choiceType.setDeterminant(readDeterminantAttribute());
 
     while (skipToChildElement(QStringLiteral("CHOICE_ALTERNATIVE"))) {
-        const QString name = readNameAttribute();
+        const auto name = readNameAttribute();
+        const auto presentWhenName = readPresentWhenNameAttribute();
+        const auto adaNameAttribute = readAdaNameAttribute();
+        const auto cNameAttribute = readCNameAttribute();
+        const auto presentWhen = readPresentWhenAttribute();
+        const auto location = readLocationFromAttributes();
 
         choiceType.addAlternative(name,
                                   {name,
-                                   readPresentWhenNameAttribute(),
-                                   readAdaNameAttribute(),
-                                   readCNameAttribute(),
-                                   readPresentWhenAttribute(),
-                                   readLocationFromAttributes(),
+                                   presentWhenName,
+                                   adaNameAttribute,
+                                   cNameAttribute,
+                                   presentWhen,
+                                   location,
                                    findAndReadType()});
 
         m_xmlReader.skipCurrentElement();

--- a/src/lib/astxmlparser.cpp
+++ b/src/lib/astxmlparser.cpp
@@ -28,6 +28,7 @@
 
 #include <data/sourcelocation.h>
 
+#include <data/types/choice.h>
 #include <data/types/enumerated.h>
 #include <data/types/integer.h>
 #include <data/types/integeracnparams.h>
@@ -388,6 +389,26 @@ int AstXmlParser::readCharPossitionInLineAttribute()
     return m_xmlReader.attributes().value(QStringLiteral("CharPositionInLine")).toInt();
 }
 
+QString AstXmlParser::readPresentWhenNameAttribute()
+{
+    return m_xmlReader.attributes().value("PresentWhenName").toString();
+}
+
+QString AstXmlParser::readAdaNameAttribute()
+{
+    return m_xmlReader.attributes().value("AdaName").toString();
+}
+
+QString AstXmlParser::readCNameAttribute()
+{
+    return m_xmlReader.attributes().value("CName").toString();
+}
+
+QString AstXmlParser::readPresentWhenAttribute()
+{
+    return m_xmlReader.attributes().value("present-when").toString();
+}
+
 void AstXmlParser::readImportedModules()
 {
     while (nextRequiredElementIs(QStringLiteral("ImportedModule")))
@@ -544,7 +565,7 @@ void AstXmlParser::readTypeContents(const QStringRef &name, Data::Types::Type &t
     else if (name == QStringLiteral("SEQUENCE_OF"))
         readSequenceOf(type);
     else if (name == QStringLiteral("CHOICE"))
-        readChoice();
+        readChoice(type);
     else if (name == QStringLiteral("REFERENCE_TYPE"))
         readReferenceType();
     else if (name == QStringLiteral("INTEGER"))
@@ -577,10 +598,22 @@ void AstXmlParser::readSequenceOf(Data::Types::Type &type)
     }
 }
 
-void AstXmlParser::readChoice()
+void AstXmlParser::readChoice(Data::Types::Type &type)
 {
+    auto &choiceType = dynamic_cast<Data::Types::Choice &>(type);
+
     while (skipToChildElement(QStringLiteral("CHOICE_ALTERNATIVE"))) {
-        findAndReadType();
+        const QString name = readNameAttribute();
+
+        choiceType.addAlternative(name,
+                                  {name,
+                                   readPresentWhenNameAttribute(),
+                                   readAdaNameAttribute(),
+                                   readCNameAttribute(),
+                                   readPresentWhenAttribute(),
+                                   readLocationFromAttributes(),
+                                   findAndReadType()});
+
         m_xmlReader.skipCurrentElement();
     }
 }

--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -67,6 +67,10 @@ private:
     QString readNameAttribute();
     int readLineAttribute();
     int readCharPossitionInLineAttribute();
+    QString readPresentWhenNameAttribute();
+    QString readAdaNameAttribute();
+    QString readCNameAttribute();
+    QString readPresentWhenAttribute();
     bool isParametrizedTypeInstance() const;
 
     void readImportedModule();
@@ -92,7 +96,7 @@ private:
 
     void readSequence();
     void readSequenceOf(Data::Types::Type &type);
-    void readChoice();
+    void readChoice(Data::Types::Type &type);
     void readReferenceType();
 
     void readInteger(Data::Types::Type &type);

--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -67,6 +67,7 @@ private:
     QString readNameAttribute();
     int readLineAttribute();
     int readCharPossitionInLineAttribute();
+    QString readDeterminantAttribute();
     QString readPresentWhenNameAttribute();
     QString readAdaNameAttribute();
     QString readCNameAttribute();

--- a/src/lib/data/types/choice.cpp
+++ b/src/lib/data/types/choice.cpp
@@ -29,6 +29,32 @@
 
 using namespace MalTester::Data::Types;
 
+ChoiceAlternative::ChoiceAlternative(const QString &name,
+                                     const QString &presentWhenName,
+                                     const QString &adaName,
+                                     const QString &cName,
+                                     const QString &presentWhen,
+                                     const SourceLocation &location,
+                                     std::unique_ptr<Type> type)
+    : m_name(name)
+    , m_presentWhenName(presentWhenName)
+    , m_adaName(adaName)
+    , m_cName(cName)
+    , m_presentWhen(presentWhen)
+    , m_location(location)
+    , m_type(std::move(type))
+{}
+
+ChoiceAlternative::ChoiceAlternative(const ChoiceAlternative &other)
+    : m_name(other.m_name)
+    , m_presentWhenName(other.m_presentWhenName)
+    , m_adaName(other.m_adaName)
+    , m_cName(other.m_cName)
+    , m_presentWhen(other.m_presentWhen)
+    , m_location(other.m_location)
+    , m_type(other.m_type->clone())
+{}
+
 std::unique_ptr<Type> Choice::clone() const
 {
     return std::make_unique<Choice>(*this);
@@ -37,4 +63,9 @@ std::unique_ptr<Type> Choice::clone() const
 void Choice::accept(TypeVisitor &visitor)
 {
     visitor.visit(*this);
+}
+
+void Choice::addAlternative(const QString &key, const ChoiceAlternative &alt)
+{
+    m_alternatives.insert(std::pair<QString, ChoiceAlternative>(key, alt));
 }

--- a/src/lib/data/types/choice.cpp
+++ b/src/lib/data/types/choice.cpp
@@ -27,6 +27,7 @@
 
 #include "typevisitor.h"
 
+using namespace MalTester::Data;
 using namespace MalTester::Data::Types;
 
 ChoiceAlternative::ChoiceAlternative(const QString &name,

--- a/src/lib/data/types/choice.h
+++ b/src/lib/data/types/choice.h
@@ -83,7 +83,11 @@ public:
     const Alternatives &alternatives() const { return m_alternatives; }
     void addAlternative(const QString &key, const ChoiceAlternative &alt);
 
+    void setDeterminant(const QString &determinant) { m_determinant = determinant; }
+    const QString &determinant() const { return m_determinant; }
+
 private:
+    QString m_determinant;
     Alternatives m_alternatives;
 };
 

--- a/src/lib/data/types/choice.h
+++ b/src/lib/data/types/choice.h
@@ -27,11 +27,46 @@
 
 #include <QString>
 
+#include <data/sourcelocation.h>
+
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
+
+class ChoiceAlternative
+{
+public:
+    ChoiceAlternative() = default;
+    ChoiceAlternative(const QString &name,
+                      const QString &presentWhenName,
+                      const QString &adaName,
+                      const QString &cName,
+                      const QString &presentWhen,
+                      const SourceLocation &location,
+                      std::unique_ptr<Type> type);
+
+    ChoiceAlternative(const ChoiceAlternative &other);
+
+    const QString &name() const { return m_name; }
+    const QString &presentWhenName() const { return m_presentWhenName; }
+    const QString &adaName() const { return m_adaName; }
+    const QString &cName() const { return m_cName; }
+    const QString &presentWhen() const { return m_presentWhen; }
+    const SourceLocation &location() const { return m_location; }
+    const Type &type() const { return *m_type; }
+
+private:
+    QString m_name;
+    QString m_presentWhenName;
+    QString m_adaName;
+    QString m_cName;
+    QString m_presentWhen;
+
+    SourceLocation m_location;
+    std::unique_ptr<Type> m_type;
+};
 
 class Choice : public Type
 {
@@ -42,6 +77,14 @@ public:
     QString name() const override { return QLatin1String("CHOICE"); }
     void accept(TypeVisitor &visitor) override;
     std::unique_ptr<Type> clone() const override;
+
+    using Alternatives = std::map<QString, ChoiceAlternative>;
+
+    const Alternatives &alternatives() const { return m_alternatives; }
+    void addAlternative(const QString &key, const ChoiceAlternative &alt);
+
+private:
+    Alternatives m_alternatives;
 };
 
 } // namespace Types

--- a/src/tests/astxmlparser_tests.cpp
+++ b/src/tests/astxmlparser_tests.cpp
@@ -1255,7 +1255,7 @@ void AstXmlParserTests::test_sequenceOfAssignmentWithAcnParams()
     const auto sequenceOfType = dynamic_cast<const Data::Types::SequenceOf *>(type->type());
 
     QVERIFY(sequenceOfType != nullptr);
-    QCOMPARE(sequenceOfType->size(), QString("n"));
+    QCOMPARE(sequenceOfType->size(), QStringLiteral("n"));
 }
 
 void AstXmlParserTests::test_choiceAlternatives()
@@ -1295,7 +1295,7 @@ void AstXmlParserTests::test_choiceAlternatives()
     auto alternatives = choiceType->alternatives();
 
     QCOMPARE(alternatives.size(), static_cast<unsigned int>(1));
-    auto alternative = alternatives.find(QString("i1"));
+    auto alternative = alternatives.find(QStringLiteral("i1"));
 
     QVERIFY(alternative != alternatives.end());
     QCOMPARE(alternative->second.presentWhenName(), QStringLiteral("i1"));
@@ -1308,6 +1308,46 @@ void AstXmlParserTests::test_choiceAlternatives()
     QCOMPARE(location.column(), 4);
 
     QCOMPARE(alternative->second.type().name(), QStringLiteral("INTEGER"));
+}
+
+void AstXmlParserTests::test_choiceAlternativesWithAcnParams()
+{
+    parse(R"(<?xml version="1.0" encoding="utf-8"?>)"
+          R"(<AstRoot>)"
+          R"(  <Asn1File FileName="Test2File.asn">)"
+          R"(    <Modules>)"
+          R"(      <Module Name="Defs" Line="13" CharPositionInLine="42">)"
+          R"(        <TypeAssignments>)"
+          R"(          <TypeAssignment Name="MyChoice" Line="5" CharPositionInLine="0">"
+          R"(            <Asn1Type id="MyChoiceModel.MyChoice" Line="5" CharPositionInLine="13" ParameterizedTypeInstance="false">"
+          R"(              <CHOICE determinant="deter">"
+          R"(                <CHOICE_ALTERNATIVE Name="i1" Line="7" CharPositionInLine="4" PresentWhenName="i1" AdaName="i1" CName="i1" present-when="type = 1">"
+          R"(                  <Asn1Type id="MyChoiceModel.MyChoice.i1" Line="7" CharPositionInLine="7" ParameterizedTypeInstance="false">"
+          R"(                    <INTEGER>"
+          R"(                      <Constraints />"
+          R"(                      <WithComponentConstraints />"
+          R"(                    </INTEGER>"
+          R"(                  </Asn1Type>"
+          R"(                </CHOICE_ALTERNATIVE>"
+          R"(                <Constraints />"
+          R"(                <WithComponentConstraints />"
+          R"(              </CHOICE>"
+          R"(            </Asn1Type>"
+          R"(          </TypeAssignment>"
+          R"(        </TypeAssignments>)"
+          R"(      </Module>)"
+          R"(    </Modules>)"
+          R"(  </Asn1File>)"
+          R"(</AstRoot>)");
+
+    const auto type = m_parsedData["Test2File.asn"]->definitions("Defs")->type("MyChoice");
+    const auto choiceType = dynamic_cast<const Data::Types::Choice *>(type->type());
+
+    QCOMPARE(choiceType->determinant(), QStringLiteral("deter"));
+
+    auto alternatives = choiceType->alternatives();
+    auto alternative = alternatives.find(QStringLiteral("i1"));
+    QCOMPARE(alternative->second.presentWhen(), QStringLiteral("type = 1"));
 }
 
 void AstXmlParserTests::parsingFails(const QString &xmlData)

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -79,6 +79,7 @@ private slots:
     void test_sequenceOfAssignmentWithAcnParams();
 
     void test_choiceAlternatives();
+    void test_choiceAlternativesWithAcnParams();
 
 private:
     void setXmlData(const QString &str);

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -78,6 +78,8 @@ private slots:
     void test_sequenceOfAssignmentWithRangeConstraintInsideSizeConstraint();
     void test_sequenceOfAssignmentWithAcnParams();
 
+    void test_choiceAlternatives();
+
 private:
     void setXmlData(const QString &str);
     void parsingFails(const QString &xmlData);


### PR DESCRIPTION
This pull request include parsing `CHOICE` children (which are called _alternatives_) and ACN params : `present-when` and `determinant` . There are no constraints for choice. 