### PR TITLE
Asnide 333 parse sequence of items type

### DIFF
--- a/src/app/inputparametersparser.cpp
+++ b/src/app/inputparametersparser.cpp
@@ -126,9 +126,9 @@ RunParameters::CcsdsWrap InputParametersParser::readCcsdsValue()
 void InputParametersParser::printUsageAndExit(const QString &message)
 {
     if (!message.isEmpty())
-        qInfo(qPrintable(message));
+        qInfo("%s", qPrintable(message));
 
-    qInfo(qPrintable(m_parser.helpText()));
+    qInfo("%s", qPrintable(m_parser.helpText()));
 
     exit(1);
 }

--- a/src/lib/astfilegenerator.cpp
+++ b/src/lib/astfilegenerator.cpp
@@ -114,7 +114,9 @@ AstFileGenerator::Result AstFileGenerator::handleTimeout() const
 void AstFileGenerator::writeMessage(const QString &message) const
 {
     auto fullMsg = m_params.m_asn1SccCommand + ": " + message;
+    qCritical("asn1scc.MalTester: %s", qPrintable(fullMsg));
 
-    qCritical(m_process->readAll());
-    qCritical(qPrintable(fullMsg));
+    auto processMsg = m_process->readAll();
+    if (!processMsg.isEmpty())
+        qCritical("asn1scc.MalTester: %s", qPrintable(processMsg));
 }

--- a/src/lib/astxmlparser.cpp
+++ b/src/lib/astxmlparser.cpp
@@ -594,12 +594,14 @@ void AstXmlParser::readSequence()
 void AstXmlParser::readSequenceOf(Data::Types::Type &type)
 {
     while (m_xmlReader.readNextStartElement()) {
-        if (m_xmlReader.name() == QStringLiteral("Constraints"))
+        if (m_xmlReader.name() == QStringLiteral("Constraints")) {
             readRanges(type, "IntegerValue");
-        else if (m_xmlReader.name() == QStringLiteral("Asn1Type"))
-            readType();
-        else
+        } else if (m_xmlReader.name() == QStringLiteral("Asn1Type")) {
+            auto &sequenceOf = dynamic_cast<Data::Types::SequenceOf &>(type);
+            sequenceOf.setItemsType(readType());
+        } else {
             m_xmlReader.skipCurrentElement();
+        }
     }
 }
 

--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -67,11 +67,6 @@ private:
     QString readNameAttribute();
     int readLineAttribute();
     int readCharPossitionInLineAttribute();
-    QString readDeterminantAttribute();
-    QString readPresentWhenNameAttribute();
-    QString readAdaNameAttribute();
-    QString readCNameAttribute();
-    QString readPresentWhenAttribute();
     bool isParametrizedTypeInstance() const;
 
     void readImportedModule();
@@ -105,7 +100,6 @@ private:
 
     void readEnumerated(Data::Types::Type &type);
     void readEnumeratedItem(Data::Types::Type &type);
-    int readValueFromAttributes();
 
     void readConstraints(Data::Types::Type &type, const QString &valName);
     void readConstraint(std::unique_ptr<Data::Types::Type> &type, const QString &valName);

--- a/src/lib/data/types/sequenceof.cpp
+++ b/src/lib/data/types/sequenceof.cpp
@@ -34,6 +34,13 @@ void SequenceOf::accept(TypeVisitor &visitor)
     visitor.visit(*this);
 }
 
+SequenceOf::SequenceOf(const SequenceOf &other)
+    : Type(other)
+    , WithConstraints<IntegerConstraints>(other)
+    , m_size(other.m_size)
+    , m_itemsType(other.m_itemsType->clone())
+{}
+
 std::unique_ptr<Type> SequenceOf::clone() const
 {
     return std::make_unique<SequenceOf>(*this);

--- a/src/lib/data/types/sequenceof.h
+++ b/src/lib/data/types/sequenceof.h
@@ -38,7 +38,7 @@ class SequenceOf : public Type, public WithConstraints<IntegerConstraints>
 {
 public:
     SequenceOf() = default;
-    SequenceOf(const SequenceOf &other) = default;
+    SequenceOf(const SequenceOf &other);
 
     QString name() const override { return QLatin1String("SEQUENCE OF"); }
     void accept(TypeVisitor &visitor) override;
@@ -47,8 +47,12 @@ public:
     QString size() const { return m_size; }
     void setSize(const QString &size) { m_size = size; }
 
+    const Type &itemsType() const { return *m_itemsType; }
+    void setItemsType(std::unique_ptr<Type> itemsType) { m_itemsType = std::move(itemsType); }
+
 private:
     QString m_size;
+    std::unique_ptr<Type> m_itemsType;
 };
 
 } // namespace Types

--- a/src/tests/astxmlparser_tests.cpp
+++ b/src/tests/astxmlparser_tests.cpp
@@ -420,7 +420,7 @@ void AstXmlParserTests::test_choiceTypeAssignment()
     QCOMPARE(ref->second->module(), QStringLiteral("Other"));
 }
 
-void AstXmlParserTests::test_sequenceOfTypeAssingment()
+void AstXmlParserTests::test_sequenceOfTypeAssingmentOfReferencedType()
 {
     parse(R"(<?xml version="1.0" encoding="utf-8"?>)"
           R"(<AstRoot>)"
@@ -462,6 +462,42 @@ void AstXmlParserTests::test_sequenceOfTypeAssingment()
 
     QCOMPARE(ref->second->name(), QStringLiteral("MyInt"));
     QCOMPARE(ref->second->module(), QStringLiteral("Other"));
+}
+
+void AstXmlParserTests::test_sequenceOfTypeAssingmentOfBuiltinType()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="Defs" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>)"
+        R"(          <TypeAssignment Name="MySeqOf" Line="11" CharPositionInLine="9">)"
+        R"(            <Asn1Type Line="12" CharPositionInLine="19">)"
+        R"(              <SEQUENCE_OF>)"
+        R"(                <Constraints/>)"
+        R"(                <WithComponentConstraints/>)"
+        R"(                <Asn1Type id="MyOtherSeqModel.SeqOf.#" Line="27" CharPositionInLine="40" ParameterizedTypeInstance="false">
+        R"(                  <INTEGER>
+        R"(                    <Constraints />
+        R"(                    <WithComponentConstraints />
+        R"(                  </INTEGER>
+        R"(                </Asn1Type>
+        R"(              </SEQUENCE_OF>"
+        R"(            </Asn1Type>)"
+        R"(          </TypeAssignment>)"
+        R"(        </TypeAssignments>)"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type = m_parsedData["Test2File.asn"]->definitions("Defs")->type("MySeqOf");
+    const auto seqOfType = dynamic_cast<const Data::Types::SequenceOf *>(type->type());
+
+    const auto &itemsType = seqOfType->itemsType();
+    QCOMPARE(itemsType.name(), QStringLiteral("INTEGER"));
 }
 
 void AstXmlParserTests::test_valueAssignment()

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -52,7 +52,8 @@ private slots:
     void test_multipleImportedType();
     void test_assignmentsAreTypeReferences();
     void test_sequenceTypeAssingment();
-    void test_sequenceOfTypeAssingment();
+    void test_sequenceOfTypeAssingmentOfReferencedType();
+    void test_sequenceOfTypeAssingmentOfBuiltinType();
     void test_choiceTypeAssignment();
     void test_valueAssignment();
     void test_importedValues();


### PR DESCRIPTION
It is worth keeping in mind that location of type is not parsed, nor stored anywhere. It was not needed before, as in IDE, type of assignment was used only to provide correct icon. If it turns out, that location of type definition is needed in test generator, than it should be probably added to most generic `Type` class. 