### PR TITLE
ASNIDE-326 Changed how Acn Components are stored within parent types

### DIFF
--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -32,8 +32,8 @@
 #include <QXmlStreamReader>
 
 #include <data/acnargument.h>
-#include <data/acncomponent.h>
 #include <data/acnparameter.h>
+#include <data/acnsequencecomponent.h>
 #include <data/definitions.h>
 #include <data/file.h>
 
@@ -104,7 +104,7 @@ private:
 
     void readSequence(Data::Types::Type &type);
     void readSequenceComponent(Data::Types::Type &type);
-    Data::AcnComponentPtr readAcnComponent();
+    void readAcnComponent(Data::Types::Type &type);
 
     void readSequenceOf(Data::Types::Type &type);
     void readChoice(Data::Types::Type &type);

--- a/src/lib/data/acnsequencecomponent.h
+++ b/src/lib/data/acnsequencecomponent.h
@@ -23,19 +23,44 @@
 ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **
 ****************************************************************************/
-#include "sequence.h"
+#pragma once
 
-#include "typevisitor.h"
+#include <memory>
+#include <vector>
 
-using namespace MalTester::Data;
-using namespace MalTester::Data::Types;
+#include <QString>
 
-void Sequence::accept(TypeVisitor &visitor)
+#include <data/sequencecomponent.h>
+
+#include <data/types/type.h>
+
+namespace MalTester {
+namespace Data {
+
+class AcnSequenceComponent : public SequenceComponent
 {
-    visitor.visit(*this);
-}
+public:
+    AcnSequenceComponent() = default;
+    ~AcnSequenceComponent() override = default;
 
-std::unique_ptr<Type> Sequence::clone() const
-{
-    return std::make_unique<Sequence>(*this);
-}
+    AcnSequenceComponent(const QString &id, const QString &name, std::unique_ptr<Types::Type> type)
+        : SequenceComponent(name, std::move(type))
+        , m_id(id)
+    {}
+
+    AcnSequenceComponent(const AcnSequenceComponent &other)
+        : SequenceComponent(other)
+        , m_id(other.id())
+    {}
+
+    const QString &id() const { return m_id; }
+
+private:
+    QString m_id;
+};
+
+using AcnSequenceComponentPtr = std::unique_ptr<AcnSequenceComponent>;
+using AcnSequenceComponentPtrs = std::vector<AcnSequenceComponentPtr>;
+
+} // namespace Data
+} // namespace MalTester

--- a/src/lib/data/asnsequencecomponent.h
+++ b/src/lib/data/asnsequencecomponent.h
@@ -23,19 +23,38 @@
 ** along with this program.  If not, see <http://www.gnu.org/licenses/>.
 **
 ****************************************************************************/
-#include "sequence.h"
+#pragma once
 
-#include "typevisitor.h"
+#include <data/sequencecomponent.h>
 
-using namespace MalTester::Data;
-using namespace MalTester::Data::Types;
+namespace MalTester {
+namespace Data {
 
-void Sequence::accept(TypeVisitor &visitor)
+class AsnSequenceComponent : public SequenceComponent
 {
-    visitor.visit(*this);
-}
+public:
+    AsnSequenceComponent() = default;
+    ~AsnSequenceComponent() override = default;
 
-std::unique_ptr<Type> Sequence::clone() const
-{
-    return std::make_unique<Sequence>(*this);
-}
+    AsnSequenceComponent(const QString &name, const QString &presentWhen, const SourceLocation &location, std::unique_ptr<Types::Type> type)
+        : SequenceComponent(name, std::move(type))
+        , m_presentWhen(presentWhen)
+        , m_location(location)
+    {}
+
+    AsnSequenceComponent(const AsnSequenceComponent &other)
+        : SequenceComponent(other)
+        , m_presentWhen(other.m_presentWhen)
+        , m_location(other.m_location)
+    {}
+
+    const SourceLocation &location() const { return m_location; }
+    const QString &presentWhen() const { return m_presentWhen; }
+
+private:
+    QString m_presentWhen;
+    SourceLocation m_location;
+};
+
+} // namespace Data
+} // namespace MalTester

--- a/src/lib/data/sequencecomponent.h
+++ b/src/lib/data/sequencecomponent.h
@@ -26,43 +26,38 @@
 #pragma once
 
 #include <memory>
-#include <vector>
 
 #include <QString>
 
+#include <data/sourcelocation.h>
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 
-class AcnComponent
+class SequenceComponent
 {
 public:
-    AcnComponent() = default;
-    AcnComponent(const QString &id, const QString &name, std::unique_ptr<Types::Type> type)
-        : m_id(id)
-        , m_name(name)
+    SequenceComponent() = default;
+    SequenceComponent(const QString &name, std::unique_ptr<Types::Type> type)
+        : m_name(name)
         , m_type(std::move(type))
     {}
 
-    AcnComponent(const AcnComponent &other)
-        : m_id(other.id())
-        , m_name(other.name())
+    SequenceComponent(const SequenceComponent &other)
+        : m_name(other.m_name)
         , m_type(other.m_type->clone())
     {}
 
-    const QString &id() const { return m_id; }
+    virtual ~SequenceComponent() = default;
+
     const QString &name() const { return m_name; }
     const Types::Type &type() const { return *m_type; }
 
 private:
-    QString m_id;
     QString m_name;
     std::unique_ptr<Types::Type> m_type;
 };
-
-using AcnComponentPtr = std::unique_ptr<AcnComponent>;
-using AcnComponentPtrs = std::vector<AcnComponentPtr>;
 
 } // namespace Data
 } // namespace MalTester

--- a/src/lib/data/types/choice.cpp
+++ b/src/lib/data/types/choice.cpp
@@ -58,7 +58,7 @@ ChoiceAlternative::ChoiceAlternative(const ChoiceAlternative &other)
 
 Choice::Choice(const Choice &other)
     : Type(other)
-    , AcnParametrizableCollection<ChoiceAlternative>(other)
+    , AcnParameterizableCollection<ChoiceAlternative>(other)
 {
     for (const auto &parameter : other.m_parameters)
         addParameter(std::make_unique<AcnParameter>(*parameter));

--- a/src/lib/data/types/choice.h
+++ b/src/lib/data/types/choice.h
@@ -30,7 +30,7 @@
 #include <data/acnparameter.h>
 #include <data/sourcelocation.h>
 
-#include <data/types/acnparameterizablecollection.h>
+#include <data/types/acnparameterizablecomposite.h>
 #include <data/types/type.h>
 
 namespace MalTester {
@@ -70,7 +70,7 @@ private:
     std::unique_ptr<Type> m_type;
 };
 
-class Choice : public Type, public AcnParametrizableCollection<ChoiceAlternative>
+class Choice : public Type, public AcnParameterizableCollection<ChoiceAlternative>
 {
 public:
     Choice() = default;

--- a/src/lib/data/types/sequence.h
+++ b/src/lib/data/types/sequence.h
@@ -27,54 +27,24 @@
 
 #include <QString>
 
-#include <data/acncomponent.h>
-#include <data/sourcelocation.h>
+#include <data/sequencecomponent.h>
 
-#include <data/types/acnparameterizablecollection.h>
+#include <data/types/acnparameterizablecomposite.h>
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
 
-class SequenceComponent
-{
-public:
-    SequenceComponent() = default;
-    SequenceComponent(const QString &name,
-                      const QString &presentWhen,
-                      const SourceLocation &location,
-                      std::unique_ptr<Type> type);
-
-    SequenceComponent(const SequenceComponent &other);
-
-    const QString &name() const { return m_name; }
-    const SourceLocation &location() const { return m_location; }
-    const Type &type() const { return *m_type; }
-    const QString &presentWhen() const { return m_presentWhen; }
-
-private:
-    QString m_name;
-    QString m_presentWhen;
-    SourceLocation m_location;
-    std::unique_ptr<Type> m_type;
-};
-
-class Sequence : public Type, public AcnParametrizableCollection<SequenceComponent>
+class Sequence : public Type, public AcnParameterizableCollection<SequenceComponent>
 {
 public:
     Sequence() = default;
-    Sequence(const Sequence &other);
+    Sequence(const Sequence &other) = default;
 
     QString name() const override { return QLatin1String("SEQUENCE"); }
     void accept(TypeVisitor &visitor) override;
     std::unique_ptr<Type> clone() const override;
-
-    const AcnComponentPtrs &acnComponents() const { return m_acnComponents; }
-    void addAcnComponent(AcnComponentPtr component);
-
-private:
-    AcnComponentPtrs m_acnComponents;
 };
 
 } // namespace Types

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -57,7 +57,9 @@ HEADERS += \
     data/visitor.h \
     data/visitorwithvalue.h \
     data/acnparameter.h \
-    data/acncomponent.h \
+    data/asnsequencecomponent.h \
+    data/acnsequencecomponent.h \
+    data/sequencecomponent.h \
     data/acnargument.h \
     \
     data/types/typefactory.h \
@@ -79,7 +81,7 @@ HEADERS += \
     data/types/sequenceof.h \
     data/types/real.h \
     data/types/constraints.h \
-    data/types/acnparameterizablecollection.h \
+    data/types/acnparameterizablecomposite.h \
     \
     astxmlparser.h \
     runparameters.h \


### PR DESCRIPTION
Previously there where two collections to store Sequence Components: one capable of storing components present in asn.1 files, the other capable of storing components introduced in acn files. Both collections were implements as std::map. Now only one collection, implemented as std::vector is used. 

PS. Build might be failing, but I believe this is travis issue. 