### PR TITLE
Asnide 330 parsing string constraints

### DIFF
--- a/src/lib/astxmlparser.cpp
+++ b/src/lib/astxmlparser.cpp
@@ -172,34 +172,24 @@ public:
 
     void visit(Data::Types::BitString &type) override
     {
-        addRangeToStringType(QStringLiteral("IntegerValue"),
-                             QStringLiteral("BitStringValue"),
-                             type.integerConstraints(),
-                             type.stringConstraints());
+        addRangeToStringType(QStringLiteral("IntegerValue"), QStringLiteral("BitStringValue"), type);
     }
 
     void visit(Data::Types::OctetString &type) override
     {
         addRangeToStringType(QStringLiteral("IntegerValue"),
                              QStringLiteral("OctetStringValue"),
-                             type.integerConstraints(),
-                             type.stringConstraints());
+                             type);
     }
 
     void visit(Data::Types::IA5String &type) override
     {
-        addRangeToStringType(QStringLiteral("IntegerValue"),
-                             QStringLiteral("StringValue"),
-                             type.integerConstraints(),
-                             type.stringConstraints());
+        addRangeToStringType(QStringLiteral("IntegerValue"), QStringLiteral("StringValue"), type);
     }
 
     void visit(Data::Types::NumericString &type) override
     {
-        addRangeToStringType(QStringLiteral("IntegerValue"),
-                             QStringLiteral("StringValue"),
-                             type.integerConstraints(),
-                             type.stringConstraints());
+        addRangeToStringType(QStringLiteral("IntegerValue"), QStringLiteral("StringValue"), type);
     }
 
     void visit(Data::Types::Enumerated &type) override
@@ -261,8 +251,7 @@ private:
 
     void addRangeToStringType(const QString &intConstraintName,
                               const QString &stringConstraintName,
-                              Data::Types::IntegerConstraints &intConstraints,
-                              Data::Types::StringConstraints &stringConstraints)
+                              Data::Types::String &type)
     {
         if (m_begin.type != m_end.type) {
             m_xmlReader.raiseError("Range types mismatch: " + m_begin.type + " " + m_end.type);
@@ -270,9 +259,9 @@ private:
         }
 
         if (m_begin.type == intConstraintName)
-            addRange(intConstraints, "Incorrect range for String type");
+            addRange(type.integerConstraints(), "Incorrect range for String type");
         else if (m_begin.type == stringConstraintName)
-            stringConstraints.addRange(m_begin.value, m_end.value);
+            type.stringConstraints().addRange(m_begin.value, m_end.value);
     }
 
     QXmlStreamReader &m_xmlReader;
@@ -986,7 +975,7 @@ void AstXmlParser::readRanges(Data::Types::Type &type, const ConstraintTypes &va
 
 void AstXmlParser::readRange(Data::Types::Type &type, const ConstraintTypes &valName)
 {
-    AstXmlParser::Constraint a, b;
+    Constraint a, b;
     while (m_xmlReader.readNextStartElement()) {
         if (m_xmlReader.name() == QStringLiteral("a"))
             a = readValue(valName);
@@ -1002,7 +991,7 @@ void AstXmlParser::readRange(Data::Types::Type &type, const ConstraintTypes &val
 
 AstXmlParser::Constraint AstXmlParser::readValue(const ConstraintTypes &valName)
 {
-    AstXmlParser::Constraint val;
+    Constraint val;
     while (m_xmlReader.readNextStartElement()) {
         const auto &name = m_xmlReader.name().toString();
         if (valName.contains(name))

--- a/src/lib/astxmlparser.cpp
+++ b/src/lib/astxmlparser.cpp
@@ -30,6 +30,7 @@
 #include <data/sourcelocation.h>
 
 #include <data/types/acnparameterizablecomposite.h>
+#include <data/types/bitstring.h>
 #include <data/types/boolean.h>
 #include <data/types/choice.h>
 #include <data/types/enumerated.h>
@@ -171,8 +172,10 @@ public:
 
     void visit(Data::Types::BitString &type) override
     {
-        Q_UNUSED(type);
-        // TODO?
+        addRangeToStringType(QStringLiteral("IntegerValue"),
+                             QStringLiteral("BitStringValue"),
+                             type.integerConstraints(),
+                             type.stringConstraints());
     }
 
     void visit(Data::Types::OctetString &type) override
@@ -808,6 +811,8 @@ void AstXmlParser::readTypeContents(const QString &name, Data::Types::Type &type
         readIA5String(type);
     else if (name == QStringLiteral("NumericString"))
         readNumericString(type);
+    else if (name == QStringLiteral("BIT_STRING"))
+        readBitString(type);
     else
         m_xmlReader.skipCurrentElement();
 }
@@ -917,6 +922,13 @@ void AstXmlParser::readNumericString(Data::Types::Type &type)
     readConstraints(type,
                     ConstraintTypes()
                         << QStringLiteral("IntegerValue") << QStringLiteral("StringValue"));
+}
+
+void AstXmlParser::readBitString(Data::Types::Type &type)
+{
+    readConstraints(type,
+                    ConstraintTypes()
+                        << QStringLiteral("IntegerValue") << QStringLiteral("BitStringValue"));
 }
 
 void AstXmlParser::readEnumeratedItem(Data::Types::Type &type)

--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -44,6 +44,13 @@ namespace MalTester {
 class AstXmlParser
 {
 public:
+    using ConstraintTypes = QStringList;
+    struct Constraint
+    {
+        QString value;
+        QString type;
+    };
+
     explicit AstXmlParser(QXmlStreamReader &xmlReader);
 
     bool parse();
@@ -116,12 +123,16 @@ private:
     void readEnumerated(Data::Types::Type &type);
     void readEnumeratedItem(Data::Types::Type &type);
 
-    void readConstraints(Data::Types::Type &type, const QString &valName);
+    void readOctetString(Data::Types::Type &type);
+    void readIA5String(Data::Types::Type &type);
+    void readNumericString(Data::Types::Type &type);
+
+    void readConstraints(Data::Types::Type &type, const ConstraintTypes &valName);
     void readConstraint(std::unique_ptr<Data::Types::Type> &type, const QString &valName);
 
-    void readRanges(Data::Types::Type &type, const QString &valName);
-    void readRange(Data::Types::Type &type, const QString &valName);
-    QString readValue(const QString &valName);
+    void readRanges(Data::Types::Type &type, const ConstraintTypes &valName);
+    void readRange(Data::Types::Type &type, const ConstraintTypes &valName);
+    Constraint readValue(const ConstraintTypes &valName);
 
     QString readTypeAssignmentAttribute();
     QString readModuleAttribute();

--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -127,6 +127,7 @@ private:
     void readOctetString(Data::Types::Type &type);
     void readIA5String(Data::Types::Type &type);
     void readNumericString(Data::Types::Type &type);
+    void readBitString(Data::Types::Type &type);
 
     void readConstraints(Data::Types::Type &type, const ConstraintTypes &valName);
     void readConstraint(std::unique_ptr<Data::Types::Type> &type, const QString &valName);

--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -45,6 +45,7 @@ class AstXmlParser
 {
 public:
     using ConstraintTypes = QStringList;
+    // TODO: Move to Constraint?
     struct Constraint
     {
         QString value;

--- a/src/lib/astxmlparser.h
+++ b/src/lib/astxmlparser.h
@@ -44,19 +44,18 @@ namespace MalTester {
 class AstXmlParser
 {
 public:
-    using ConstraintTypes = QStringList;
-    // TODO: Move to Constraint?
-    struct Constraint
-    {
-        QString value;
-        QString type;
-    };
-
     explicit AstXmlParser(QXmlStreamReader &xmlReader);
 
     bool parse();
 
     std::map<QString, std::unique_ptr<Data::File>> takeData() { return std::move(m_data); }
+
+    using ConstraintTypes = QStringList;
+    struct Constraint
+    {
+        QString value;
+        QString type;
+    };
 
 private:
     void readAstRoot();

--- a/src/lib/data/types/bitstring.h
+++ b/src/lib/data/types/bitstring.h
@@ -27,13 +27,17 @@
 
 #include <QString>
 
+#include "constraints.h"
+
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
 
-class BitString : public Type
+class BitString : public Type,
+                  public WithConstraints<IntegerConstraints>,
+                  public WithConstraints<StringConstraints>
 {
 public:
     BitString() = default;
@@ -42,6 +46,26 @@ public:
     QString name() const override { return QLatin1String("BIT STRING"); }
     void accept(TypeVisitor &visitor) override;
     std::unique_ptr<Type> clone() const override;
+
+    IntegerConstraints &integerConstraints()
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    const IntegerConstraints &integerConstraints() const
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    StringConstraints &stringConstraints()
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
+
+    const StringConstraints &stringConstraints() const
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
 };
 
 } // namespace Types

--- a/src/lib/data/types/bitstring.h
+++ b/src/lib/data/types/bitstring.h
@@ -27,17 +27,14 @@
 
 #include <QString>
 
-#include "constraints.h"
-
+#include <data/types/string.h>
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
 
-class BitString : public Type,
-                  public WithConstraints<IntegerConstraints>,
-                  public WithConstraints<StringConstraints>
+class BitString : public String
 {
 public:
     BitString() = default;
@@ -46,26 +43,6 @@ public:
     QString name() const override { return QLatin1String("BIT STRING"); }
     void accept(TypeVisitor &visitor) override;
     std::unique_ptr<Type> clone() const override;
-
-    IntegerConstraints &integerConstraints()
-    {
-        return WithConstraints<IntegerConstraints>::constraints();
-    }
-
-    const IntegerConstraints &integerConstraints() const
-    {
-        return WithConstraints<IntegerConstraints>::constraints();
-    }
-
-    StringConstraints &stringConstraints()
-    {
-        return WithConstraints<StringConstraints>::constraints();
-    }
-
-    const StringConstraints &stringConstraints() const
-    {
-        return WithConstraints<StringConstraints>::constraints();
-    }
 };
 
 } // namespace Types

--- a/src/lib/data/types/constraints.h
+++ b/src/lib/data/types/constraints.h
@@ -65,6 +65,7 @@ private:
 using IntegerConstraints = RangeConstraints<int>;
 using RealConstraints = RangeConstraints<double>;
 using EnumeratedConstraints = RangeConstraints<int>;
+using StringConstraints = RangeConstraints<QString>;
 
 } // namespace Types
 } // namespace Data

--- a/src/lib/data/types/ia5string.h
+++ b/src/lib/data/types/ia5string.h
@@ -27,13 +27,17 @@
 
 #include <QString>
 
+#include "constraints.h"
+
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
 
-class IA5String : public Type
+class IA5String : public Type,
+                  public WithConstraints<IntegerConstraints>,
+                  public WithConstraints<StringConstraints>
 {
 public:
     IA5String() = default;
@@ -42,6 +46,26 @@ public:
     QString name() const override { return QLatin1String("IA5String"); }
     void accept(TypeVisitor &visitor) override;
     std::unique_ptr<Type> clone() const override;
+
+    IntegerConstraints &integerConstraints()
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    const IntegerConstraints &integerConstraints() const
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    StringConstraints &stringConstraints()
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
+
+    const StringConstraints &stringConstraints() const
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
 };
 
 } // namespace Types

--- a/src/lib/data/types/ia5string.h
+++ b/src/lib/data/types/ia5string.h
@@ -27,17 +27,14 @@
 
 #include <QString>
 
-#include "constraints.h"
-
+#include <data/types/string.h>
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
 
-class IA5String : public Type,
-                  public WithConstraints<IntegerConstraints>,
-                  public WithConstraints<StringConstraints>
+class IA5String : public String
 {
 public:
     IA5String() = default;
@@ -46,26 +43,6 @@ public:
     QString name() const override { return QLatin1String("IA5String"); }
     void accept(TypeVisitor &visitor) override;
     std::unique_ptr<Type> clone() const override;
-
-    IntegerConstraints &integerConstraints()
-    {
-        return WithConstraints<IntegerConstraints>::constraints();
-    }
-
-    const IntegerConstraints &integerConstraints() const
-    {
-        return WithConstraints<IntegerConstraints>::constraints();
-    }
-
-    StringConstraints &stringConstraints()
-    {
-        return WithConstraints<StringConstraints>::constraints();
-    }
-
-    const StringConstraints &stringConstraints() const
-    {
-        return WithConstraints<StringConstraints>::constraints();
-    }
 };
 
 } // namespace Types

--- a/src/lib/data/types/numericstring.h
+++ b/src/lib/data/types/numericstring.h
@@ -27,13 +27,17 @@
 
 #include <QString>
 
+#include "constraints.h"
+
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
 
-class NumericString : public Type
+class NumericString : public Type,
+                      public WithConstraints<IntegerConstraints>,
+                      public WithConstraints<StringConstraints>
 {
 public:
     NumericString() = default;
@@ -42,6 +46,26 @@ public:
     QString name() const override { return QLatin1String("NumericString"); }
     void accept(TypeVisitor &visitor) override;
     std::unique_ptr<Type> clone() const override;
+
+    IntegerConstraints &integerConstraints()
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    const IntegerConstraints &integerConstraints() const
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    StringConstraints &stringConstraints()
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
+
+    const StringConstraints &stringConstraints() const
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
 };
 
 } // namespace Types

--- a/src/lib/data/types/numericstring.h
+++ b/src/lib/data/types/numericstring.h
@@ -27,17 +27,14 @@
 
 #include <QString>
 
-#include "constraints.h"
-
+#include <data/types/string.h>
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
 
-class NumericString : public Type,
-                      public WithConstraints<IntegerConstraints>,
-                      public WithConstraints<StringConstraints>
+class NumericString : public String
 {
 public:
     NumericString() = default;
@@ -46,26 +43,6 @@ public:
     QString name() const override { return QLatin1String("NumericString"); }
     void accept(TypeVisitor &visitor) override;
     std::unique_ptr<Type> clone() const override;
-
-    IntegerConstraints &integerConstraints()
-    {
-        return WithConstraints<IntegerConstraints>::constraints();
-    }
-
-    const IntegerConstraints &integerConstraints() const
-    {
-        return WithConstraints<IntegerConstraints>::constraints();
-    }
-
-    StringConstraints &stringConstraints()
-    {
-        return WithConstraints<StringConstraints>::constraints();
-    }
-
-    const StringConstraints &stringConstraints() const
-    {
-        return WithConstraints<StringConstraints>::constraints();
-    }
 };
 
 } // namespace Types

--- a/src/lib/data/types/octetstring.h
+++ b/src/lib/data/types/octetstring.h
@@ -27,13 +27,17 @@
 
 #include <QString>
 
+#include "constraints.h"
+
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
 
-class OctetString : public Type
+class OctetString : public Type,
+                    public WithConstraints<IntegerConstraints>,
+                    public WithConstraints<StringConstraints>
 {
 public:
     OctetString() = default;
@@ -42,7 +46,28 @@ public:
     QString name() const override { return QLatin1String("OCTET STRING"); }
     void accept(TypeVisitor &visitor) override;
     std::unique_ptr<Type> clone() const override;
-};
+
+    IntegerConstraints &integerConstraints()
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    const IntegerConstraints &integerConstraints() const
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    StringConstraints &stringConstraints()
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
+
+    const StringConstraints &stringConstraints() const
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
+
+}; // namespace Types
 
 } // namespace Types
 } // namespace Data

--- a/src/lib/data/types/string.h
+++ b/src/lib/data/types/string.h
@@ -25,24 +25,42 @@
 ****************************************************************************/
 #pragma once
 
-#include <QString>
+#include "constraints.h"
 
-#include <data/types/string.h>
 #include <data/types/type.h>
 
 namespace MalTester {
 namespace Data {
 namespace Types {
 
-class OctetString : public String
+class String : public Type,
+               public WithConstraints<IntegerConstraints>,
+               public WithConstraints<StringConstraints>
 {
-public:
-    OctetString() = default;
-    OctetString(const OctetString &other) = default;
+protected:
+    String() = default;
+    String(const String &other) = default;
 
-    QString name() const override { return QLatin1String("OCTET STRING"); }
-    void accept(TypeVisitor &visitor) override;
-    std::unique_ptr<Type> clone() const override;
+public:
+    IntegerConstraints &integerConstraints()
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    const IntegerConstraints &integerConstraints() const
+    {
+        return WithConstraints<IntegerConstraints>::constraints();
+    }
+
+    StringConstraints &stringConstraints()
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
+
+    const StringConstraints &stringConstraints() const
+    {
+        return WithConstraints<StringConstraints>::constraints();
+    }
 };
 
 } // namespace Types

--- a/src/lib/lib.pro
+++ b/src/lib/lib.pro
@@ -81,6 +81,7 @@ HEADERS += \
     data/types/sequenceof.h \
     data/types/real.h \
     data/types/constraints.h \
+    data/types/string.h \
     data/types/acnparameterizablecomposite.h \
     \
     astxmlparser.h \

--- a/src/tests/astxmlparser_tests.cpp
+++ b/src/tests/astxmlparser_tests.cpp
@@ -34,9 +34,11 @@
 
 #include <data/types/boolean.h>
 #include <data/types/choice.h>
+#include <data/types/constraints.h>
 #include <data/types/enumerated.h>
 #include <data/types/integer.h>
 #include <data/types/null.h>
+#include <data/types/octetstring.h>
 #include <data/types/real.h>
 #include <data/types/sequence.h>
 #include <data/types/sequenceof.h>
@@ -1973,6 +1975,145 @@ void AstXmlParserTests::test_sequenceAcnComponents()
     QCOMPARE(intType.size(), 16);
     QCOMPARE(intType.encoding(), Data::Types::IntegerEncoding::BCD);
     QCOMPARE(intType.alignToNext(), Data::Types::AlignToNext::dword);
+}
+
+void AstXmlParserTests::test_octetStringWithSizeConstraint()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyOctetString" Line="3" CharPositionInLine="0">"
+        R"(            <Asn1Type id="MyModelToTestString.MyOctetString" Line="3" CharPositionInLine="26" ParameterizedTypeInstance="false">"
+        R"(              <OCTET_STRING>"
+        R"(                <Constraints>"
+        R"(                  <SIZE>"
+        R"(                    <IntegerValue>10</IntegerValue>"
+        R"(                  </SIZE>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </OCTET_STRING>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyOctetString");
+
+    const auto ocetStringType = dynamic_cast<const Data::Types::OctetString *>(type->type());
+    const auto &constraintRanges = ocetStringType->integerConstraints().ranges();
+
+    QCOMPARE(constraintRanges.size(), 1);
+    QVERIFY(constraintRanges.contains({10, 10}));
+}
+
+void AstXmlParserTests::test_octetStringWithRangedSizeConstraint()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyOctetString" Line="3" CharPositionInLine="0">"
+        R"(            <Asn1Type id="MyModelToTestString.MyOctetString" Line="3" CharPositionInLine="26" ParameterizedTypeInstance="false">"
+        R"(              <OCTET_STRING>"
+        R"(                <Constraints>"
+        R"(                  <SIZE>"
+        R"(                    <OR>"
+        R"(                      <OR>"
+        R"(                        <Range>"
+        R"(                          <a>"
+        R"(                            <IntegerValue>1</IntegerValue>"
+        R"(                          </a>"
+        R"(                          <b>"
+        R"(                            <IntegerValue>2</IntegerValue>"
+        R"(                          </b>"
+        R"(                        </Range>"
+        R"(                        <Range>"
+        R"(                          <a>"
+        R"(                            <IntegerValue>4</IntegerValue>"
+        R"(                          </a>"
+        R"(                          <b>"
+        R"(                            <IntegerValue>5</IntegerValue>"
+        R"(                          </b>"
+        R"(                        </Range>"
+        R"(                      </OR>"
+        R"(                      <Range>"
+        R"(                        <a>"
+        R"(                          <IntegerValue>7</IntegerValue>"
+        R"(                        </a>"
+        R"(                        <b>"
+        R"(                          <IntegerValue>8</IntegerValue>"
+        R"(                        </b>"
+        R"(                      </Range>"
+        R"(                    </OR>"
+        R"(                  </SIZE>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </OCTET_STRING>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyOctetString");
+
+    const auto ocetStringType = dynamic_cast<const Data::Types::OctetString *>(type->type());
+    const auto &constraintRanges = ocetStringType->integerConstraints().ranges();
+
+    QCOMPARE(constraintRanges.size(), 3);
+
+    QVERIFY(constraintRanges.contains({1, 2}));
+    QVERIFY(constraintRanges.contains({4, 5}));
+    QVERIFY(constraintRanges.contains({7, 8}));
+}
+
+void AstXmlParserTests::test_octetStringWithValueDefined()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyOctetString" Line="3" CharPositionInLine="0">"
+        R"(            <Asn1Type id="MyModelToTestString.MyOctetString" Line="3" CharPositionInLine="26" ParameterizedTypeInstance="false">"
+        R"(              <OCTET_STRING>
+        R"(                <Constraints>
+        R"(                  <OctetStringValue>599</OctetStringValue>
+        R"(                </Constraints>
+        R"(                <WithComponentConstraints />
+        R"(              </OCTET_STRING>
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyOctetString");
+
+    const auto ocetStringType = dynamic_cast<const Data::Types::OctetString *>(type->type());
+    const auto &constraintRanges = ocetStringType->stringConstraints().ranges();
+
+    QCOMPARE(constraintRanges.size(), 1);
+    QVERIFY(constraintRanges.contains({"599", "599"}));
 }
 
 void AstXmlParserTests::parsingFails(const QString &xmlData)

--- a/src/tests/astxmlparser_tests.cpp
+++ b/src/tests/astxmlparser_tests.cpp
@@ -36,8 +36,10 @@
 #include <data/types/choice.h>
 #include <data/types/constraints.h>
 #include <data/types/enumerated.h>
+#include <data/types/ia5string.h>
 #include <data/types/integer.h>
 #include <data/types/null.h>
+#include <data/types/numericstring.h>
 #include <data/types/octetstring.h>
 #include <data/types/real.h>
 #include <data/types/sequence.h>
@@ -2092,12 +2094,12 @@ void AstXmlParserTests::test_octetStringWithValueDefined()
         R"(        <TypeAssignments>"
         R"(          <TypeAssignment Name="MyOctetString" Line="3" CharPositionInLine="0">"
         R"(            <Asn1Type id="MyModelToTestString.MyOctetString" Line="3" CharPositionInLine="26" ParameterizedTypeInstance="false">"
-        R"(              <OCTET_STRING>
-        R"(                <Constraints>
-        R"(                  <OctetStringValue>599</OctetStringValue>
-        R"(                </Constraints>
-        R"(                <WithComponentConstraints />
-        R"(              </OCTET_STRING>
+        R"(              <OCTET_STRING>"
+        R"(                <Constraints>"
+        R"(                  <OctetStringValue>599</OctetStringValue>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </OCTET_STRING>"
         R"(            </Asn1Type>"
         R"(          </TypeAssignment>"
         R"(        </TypeAssignments>"
@@ -2114,6 +2116,317 @@ void AstXmlParserTests::test_octetStringWithValueDefined()
 
     QCOMPARE(constraintRanges.size(), 1);
     QVERIFY(constraintRanges.contains({"599", "599"}));
+}
+
+void AstXmlParserTests::test_iA5StringWithSizeConstraint()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(         <TypeAssignment Name="MyIA5String" Line="7" CharPositionInLine="0">"
+        R"(           <Asn1Type id="MyModelToTestString.MyIA5String" Line="7" CharPositionInLine="24" ParameterizedTypeInstance="false">"
+        R"(             <IA5String>"
+        R"(               <Constraints>"
+        R"(                 <SIZE>"
+        R"(                   <Range>"
+        R"(                     <a>"
+        R"(                       <IntegerValue>1</IntegerValue>"
+        R"(                     </a>"
+        R"(                     <b>"
+        R"(                       <IntegerValue>10</IntegerValue>"
+        R"(                     </b>"
+        R"(                   </Range>"
+        R"(                 </SIZE>"
+        R"(               </Constraints>"
+        R"(               <WithComponentConstraints />"
+        R"(             </IA5String>"
+        R"(           </Asn1Type>"
+        R"(         </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyIA5String");
+    const auto myIA5String = dynamic_cast<const Data::Types::IA5String *>(type->type());
+
+    const auto &constraintRanges = myIA5String->integerConstraints().ranges();
+
+    QCOMPARE(constraintRanges.size(), 1);
+    QVERIFY(constraintRanges.contains({1, 10}));
+}
+
+void AstXmlParserTests::test_iA5StringWithValueConstraint()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(         <TypeAssignment Name="MyIA5String" Line="7" CharPositionInLine="0">"
+        R"(           <Asn1Type id="MyModelToTestString.MyIA5String" Line="7" CharPositionInLine="24" ParameterizedTypeInstance="false">"
+        R"(             <IA5String>"
+        R"(               <Constraints>"
+        R"(                 <AND>"
+        R"(                   <SIZE>"
+        R"(                     <Range>"
+        R"(                       <a>"
+        R"(                         <IntegerValue>1</IntegerValue>"
+        R"(                       </a>"
+        R"(                       <b>"
+        R"(                         <IntegerValue>10</IntegerValue>"
+        R"(                       </b>"
+        R"(                     </Range>"
+        R"(                   </SIZE>"
+        R"(                   <ALPHA>"
+        R"(                     <OR>"
+        R"(                       <OR>"
+        R"(                         <Range>"
+        R"(                           <a>"
+        R"(                             <StringValue>A</StringValue>"
+        R"(                           </a>"
+        R"(                           <b>"
+        R"(                             <StringValue>D</StringValue>"
+        R"(                           </b>"
+        R"(                         </Range>"
+        R"(                         <Range>"
+        R"(                           <a>"
+        R"(                             <StringValue>X</StringValue>"
+        R"(                           </a>"
+        R"(                           <b>"
+        R"(                             <StringValue>Z</StringValue>"
+        R"(                           </b>"
+        R"(                         </Range>"
+        R"(                       </OR>"
+        R"(                       <Range>"
+        R"(                         <a>"
+        R"(                           <StringValue>1</StringValue>"
+        R"(                         </a>"
+        R"(                         <b>"
+        R"(                           <StringValue>9</StringValue>"
+        R"(                         </b>"
+        R"(                       </Range>"
+        R"(                     </OR>"
+        R"(                   </ALPHA>"
+        R"(                 </AND>"
+        R"(               </Constraints>"
+        R"(               <WithComponentConstraints />"
+        R"(             </IA5String>"
+        R"(           </Asn1Type>"
+        R"(         </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyIA5String");
+    const auto myIA5String = dynamic_cast<const Data::Types::IA5String *>(type->type());
+
+    const auto &integerRanges = myIA5String->integerConstraints().ranges();
+    QCOMPARE(integerRanges.size(), 1);
+    QVERIFY(integerRanges.contains({1, 10}));
+
+    const auto &stringRanges = myIA5String->stringConstraints().ranges();
+    QCOMPARE(stringRanges.size(), 3);
+    QVERIFY(stringRanges.contains({QStringLiteral("A"), QStringLiteral("D")}));
+    QVERIFY(stringRanges.contains({QStringLiteral("X"), QStringLiteral("Z")}));
+    QVERIFY(stringRanges.contains({QStringLiteral("1"), QStringLiteral("9")}));
+}
+
+void AstXmlParserTests::test_iA5StringWithValueDefined()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(         <TypeAssignment Name="MyIA5String" Line="7" CharPositionInLine="0">"
+        R"(           <Asn1Type id="MyModelToTestString.MyIA5String" Line="7" CharPositionInLine="24" ParameterizedTypeInstance="false">"
+        R"(             <IA5String>"
+        R"(               <Constraints>"
+        R"(                 <StringValue>Text</StringValue>"
+        R"(               </Constraints>"
+        R"(               <WithComponentConstraints />"
+        R"(             </IA5String>"
+        R"(           </Asn1Type>"
+        R"(         </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyIA5String");
+    const auto myIA5String = dynamic_cast<const Data::Types::IA5String *>(type->type());
+
+    const auto &stringRanges = myIA5String->stringConstraints().ranges();
+    QCOMPARE(stringRanges.size(), 1);
+    QVERIFY(stringRanges.contains({QStringLiteral("Text"), QStringLiteral("Text")}));
+}
+
+void AstXmlParserTests::test_numericStringWithSizeConstraint()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyNumericString" Line="11" CharPositionInLine="0">"
+        R"(            <Asn1Type id="MyModelToTestString.MyNumericString" Line="11" CharPositionInLine="28" ParameterizedTypeInstance="false">"
+        R"(              <NumericString>"
+        R"(                <Constraints>"
+        R"(                  <SIZE>"
+        R"(                    <Range>"
+        R"(                      <a>"
+        R"(                        <IntegerValue>10</IntegerValue>"
+        R"(                      </a>"
+        R"(                      <b>"
+        R"(                        <IntegerValue>100</IntegerValue>"
+        R"(                      </b>"
+        R"(                    </Range>"
+        R"(                  </SIZE>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </NumericString>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyNumericString");
+    const auto numericString = dynamic_cast<const Data::Types::NumericString *>(type->type());
+
+    const auto &constraintRanges = numericString->integerConstraints().ranges();
+
+    QCOMPARE(constraintRanges.size(), 1);
+    QVERIFY(constraintRanges.contains({10, 100}));
+}
+
+void AstXmlParserTests::test_numericStringWithValueConstraint()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyNumericString" Line="11" CharPositionInLine="0">"
+        R"(            <Asn1Type id="MyModelToTestString.MyNumericString" Line="11" CharPositionInLine="28" ParameterizedTypeInstance="false">"
+        R"(              <NumericString>"
+        R"(                <Constraints>"
+        R"(                  <AND>"
+        R"(                    <SIZE>"
+        R"(                      <IntegerValue>10</IntegerValue>"
+        R"(                    </SIZE>"
+        R"(                    <ALPHA>"
+        R"(                      <OR>"
+        R"(                        <Range>"
+        R"(                          <a>"
+        R"(                            <StringValue>1</StringValue>"
+        R"(                          </a>"
+        R"(                          <b>"
+        R"(                            <StringValue>5</StringValue>"
+        R"(                          </b>"
+        R"(                        </Range>"
+        R"(                        <AND>"
+        R"(                          <Range>"
+        R"(                            <a>"
+        R"(                              <StringValue>6</StringValue>"
+        R"(                            </a>"
+        R"(                            <b>"
+        R"(                              <StringValue>9</StringValue>"
+        R"(                            </b>"
+        R"(                          </Range>"
+        R"(                          <Range>"
+        R"(                            <a>"
+        R"(                              <StringValue>1</StringValue>"
+        R"(                            </a>"
+        R"(                            <b>"
+        R"(                              <StringValue>8</StringValue>"
+        R"(                            </b>"
+        R"(                          </Range>"
+        R"(                        </AND>"
+        R"(                      </OR>"
+        R"(                    </ALPHA>"
+        R"(                  </AND>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </NumericString>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyNumericString");
+    const auto numericString = dynamic_cast<const Data::Types::NumericString *>(type->type());
+
+    const auto &integerRanges = numericString->integerConstraints().ranges();
+    QCOMPARE(integerRanges.size(), 1);
+    QVERIFY(integerRanges.contains({10, 10}));
+
+    const auto &stringRanges = numericString->stringConstraints().ranges();
+    QCOMPARE(stringRanges.size(), 3);
+    QVERIFY(stringRanges.contains({QStringLiteral("1"), QStringLiteral("5")}));
+    QVERIFY(stringRanges.contains({QStringLiteral("6"), QStringLiteral("9")}));
+    QVERIFY(stringRanges.contains({QStringLiteral("1"), QStringLiteral("8")}));
+}
+
+void AstXmlParserTests::test_numericStringWithValueDefined()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyNumericString" Line="11" CharPositionInLine="0">"
+        R"(            <Asn1Type id="MyModelToTestString.MyNumericString" Line="11" CharPositionInLine="28" ParameterizedTypeInstance="false">"
+        R"(              <NumericString>"
+        R"(                <Constraints>"
+        R"(                  <StringValue>12345_ABCD</StringValue>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </NumericString>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyNumericString");
+    const auto numericString = dynamic_cast<const Data::Types::NumericString *>(type->type());
+
+    const auto &stringRanges = numericString->stringConstraints().ranges();
+    QCOMPARE(stringRanges.size(), 1);
+    QVERIFY(stringRanges.contains({QStringLiteral("12345_ABCD"), QStringLiteral("12345_ABCD")}));
 }
 
 void AstXmlParserTests::parsingFails(const QString &xmlData)

--- a/src/tests/astxmlparser_tests.cpp
+++ b/src/tests/astxmlparser_tests.cpp
@@ -32,6 +32,7 @@
 #include <data/acnsequencecomponent.h>
 #include <data/asnsequencecomponent.h>
 
+#include <data/types/bitstring.h>
 #include <data/types/boolean.h>
 #include <data/types/choice.h>
 #include <data/types/constraints.h>
@@ -2427,6 +2428,143 @@ void AstXmlParserTests::test_numericStringWithValueDefined()
     const auto &stringRanges = numericString->stringConstraints().ranges();
     QCOMPARE(stringRanges.size(), 1);
     QVERIFY(stringRanges.contains({QStringLiteral("12345_ABCD"), QStringLiteral("12345_ABCD")}));
+}
+
+void AstXmlParserTests::test_bitStringWithSizeConstraint()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyBitString" Line="7" CharPositionInLine="0">"
+        R"(            <Asn1Type id="MyModelToTestString.MyBitString" Line="7" CharPositionInLine="24" ParameterizedTypeInstance="false">"
+        R"(              <BIT_STRING>"
+        R"(                <Constraints>"
+        R"(                  <SIZE>"
+        R"(                    <IntegerValue>12</IntegerValue>"
+        R"(                  </SIZE>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </BIT_STRING>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyBitString");
+    const auto bitString = dynamic_cast<const Data::Types::BitString *>(type->type());
+
+    const auto &integerRanges = bitString->integerConstraints().ranges();
+    QCOMPARE(integerRanges.size(), 1);
+    QVERIFY(integerRanges.contains({12, 12}));
+}
+
+void AstXmlParserTests::test_bitStringWithRangedSizeConstraint()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyBitString" Line="7" CharPositionInLine="0">"
+        R"(            <Asn1Type id="MyModelToTestString.MyBitString" Line="7" CharPositionInLine="24" ParameterizedTypeInstance="false">"
+        R"(              <BIT_STRING>"
+        R"(                <Constraints>"
+        R"(                  <SIZE>"
+        R"(                    <OR>"
+        R"(                      <OR>"
+        R"(                        <Range>"
+        R"(                          <a>"
+        R"(                            <IntegerValue>10</IntegerValue>"
+        R"(                          </a>"
+        R"(                          <b>"
+        R"(                            <IntegerValue>20</IntegerValue>"
+        R"(                          </b>"
+        R"(                        </Range>"
+        R"(                        <Range>"
+        R"(                          <a>"
+        R"(                            <IntegerValue>40</IntegerValue>"
+        R"(                          </a>"
+        R"(                          <b>"
+        R"(                            <IntegerValue>50</IntegerValue>"
+        R"(                          </b>"
+        R"(                        </Range>"
+        R"(                      </OR>"
+        R"(                      <Range>"
+        R"(                        <a>"
+        R"(                          <IntegerValue>70</IntegerValue>"
+        R"(                        </a>"
+        R"(                        <b>"
+        R"(                          <IntegerValue>80</IntegerValue>"
+        R"(                        </b>"
+        R"(                      </Range>"
+        R"(                    </OR>"
+        R"(                  </SIZE>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </BIT_STRING>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyBitString");
+    const auto bitString = dynamic_cast<const Data::Types::BitString *>(type->type());
+
+    const auto &constraintRanges = bitString->integerConstraints().ranges();
+
+    QCOMPARE(constraintRanges.size(), 3);
+
+    QVERIFY(constraintRanges.contains({10, 20}));
+    QVERIFY(constraintRanges.contains({40, 50}));
+    QVERIFY(constraintRanges.contains({70, 80}));
+}
+
+void AstXmlParserTests::test_bitStringWithValueDefined()
+{
+    parse(
+        R"(<?xml version="1.0" encoding="utf-8"?>)"
+        R"(<AstRoot>)"
+        R"(  <Asn1File FileName="Test2File.asn">)"
+        R"(    <Modules>)"
+        R"(      <Module Name="TestDefinitions" Line="13" CharPositionInLine="42">)"
+        R"(        <TypeAssignments>"
+        R"(          <TypeAssignment Name="MyBitString" Line="7" CharPositionInLine="0">"
+        R"(            <Asn1Type id="MyModelToTestString.MyBitString" Line="7" CharPositionInLine="24" ParameterizedTypeInstance="false">"
+        R"(              <BIT_STRING>"
+        R"(                <Constraints>"
+        R"(                  <BitStringValue>10101011</BitStringValue>"
+        R"(                </Constraints>"
+        R"(                <WithComponentConstraints />"
+        R"(              </BIT_STRING>"
+        R"(            </Asn1Type>"
+        R"(          </TypeAssignment>"
+        R"(        </TypeAssignments>"
+        R"(      </Module>)"
+        R"(    </Modules>)"
+        R"(  </Asn1File>)"
+        R"(</AstRoot>)");
+
+    const auto type
+        = m_parsedData["Test2File.asn"]->definitions("TestDefinitions")->type("MyBitString");
+    const auto bitString = dynamic_cast<const Data::Types::BitString *>(type->type());
+
+    const auto &stringRanges = bitString->stringConstraints().ranges();
+    QCOMPARE(stringRanges.size(), 1);
+    QVERIFY(stringRanges.contains({QStringLiteral("10101011"), QStringLiteral("10101011")}));
 }
 
 void AstXmlParserTests::parsingFails(const QString &xmlData)

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -83,13 +83,17 @@ private slots:
     void test_choiceAlternatives();
     void test_choiceAlternativesWithAcnParams();
 
+    void test_booleanWithAcnParams();
+    void test_nullWithAcnParams();
+
     void test_sequnceWithAcnParams();
     void test_sequenceComponents();
     void test_sequenceComponentsWithAcnParams();
     void test_sequenceAcnComponents();
 
-    void test_booleanWithAcnParams();
-    void test_nullWithAcnParams();
+    void test_octetStringWithSizeConstraint();
+    void test_octetStringWithRangedSizeConstraint();
+    void test_octetStringWithValueDefined();
 
 private:
     template<typename Collection>

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -95,6 +95,14 @@ private slots:
     void test_octetStringWithRangedSizeConstraint();
     void test_octetStringWithValueDefined();
 
+    void test_iA5StringWithSizeConstraint();
+    void test_iA5StringWithValueConstraint();
+    void test_iA5StringWithValueDefined();
+
+    void test_numericStringWithSizeConstraint();
+    void test_numericStringWithValueConstraint();
+    void test_numericStringWithValueDefined();
+
 private:
     template<typename Collection>
     auto itemFromCollection(const Collection &col, const QString &id);

--- a/src/tests/astxmlparser_tests.h
+++ b/src/tests/astxmlparser_tests.h
@@ -103,6 +103,10 @@ private slots:
     void test_numericStringWithValueConstraint();
     void test_numericStringWithValueDefined();
 
+    void test_bitStringWithSizeConstraint();
+    void test_bitStringWithRangedSizeConstraint();
+    void test_bitStringWithValueDefined();
+
 private:
     template<typename Collection>
     auto itemFromCollection(const Collection &col, const QString &id);


### PR DESCRIPTION
Used following model to create AST, on which this solution is based. 

```
MyModelToTestString DEFINITIONS ::= BEGIN

MyOctetStringWithSize ::= OCTET STRING(SIZE(10))
MyOctetStringWithSizeRange ::= OCTET STRING(SIZE(1 .. 2 | 4 .. 5 | 7 .. 8))
MyOctetStringWithValue ::= OCTET STRING('ABCDEFABCDEF'H)

MyBitStringWithSize ::= BIT STRING(SIZE(10))
MyBitStringWithSizeRange ::= BIT STRING(SIZE(1 .. 2 | 4 .. 5 | 7 .. 8))
MyBitStringWithValue ::= BIT STRING('AB'H)

MyIA5StringWithSize ::= IA5String(SIZE(1 .. 10))
MyIA5StringWithIntersection ::= IA5String(SIZE(1 .. 10) INTERSECTION FROM (("A" .. "D") | ("X" .. "Z") | ("1" .. "9")))
MyIA5StringWithValue ::= IA5String("Text")

MyNumericStringWithSize ::= NumericString(SIZE(10 .. 100))
MyNumericStringWithIntersection ::= NumericString(SIZE(10) INTERSECTION FROM ("1" .. "5" | "6" .. "9" ^ "1" .. "8"))
MyNumericStringWithValue ::= NumericString("12345_ABCD")

END
```